### PR TITLE
Fix some tags in comparable images

### DIFF
--- a/images.txt
+++ b/images.txt
@@ -11,14 +11,14 @@ bitnami/minio-client:latest
 bitnami/prometheus:latest
 bitnami/thanos:latest
 busybox:latest
-cockroachdb/bazel:latest
+cockroachdb/bazel:latest-do-not-use
 coredns/coredns:latest
 curlimages/curl:latest
 debian:bullseye-slim
 denoland/deno:latest
 dexidp/dex:latest
 eclipse-temurin:latest
-envoyproxy/envoy:latest
+envoyproxy/envoy:v1.25-latest
 fluent/fluent-bit:latest
 fluentd:latest
 gcc:latest

--- a/images.txt
+++ b/images.txt
@@ -11,7 +11,6 @@ bitnami/minio-client:latest
 bitnami/prometheus:latest
 bitnami/thanos:latest
 busybox:latest
-cockroachdb/bazel:latest-do-not-use
 coredns/coredns:latest
 curlimages/curl:latest
 debian:bullseye-slim


### PR DESCRIPTION
Fixing some tags :)

The scan GH action failed on a couple of images because the `latest` tag does not exist.