### PR TITLE
Remove drupal:latest from images.txt

### DIFF
--- a/images.txt
+++ b/images.txt
@@ -31,7 +31,6 @@ debian:latest
 denoland/deno:latest
 dexidp/dex:latest
 docker:latest
-drupal:latest
 eclipse-mosquitto:latest
 eclipse-temurin:latest
 elasticsearch:8.7.0


### PR DESCRIPTION
There appears to be an incompatibility of this image with `trivy`. Not worth investigating, at least right now. It's better to remove it.