### PR TITLE
Remove nextcloud:latest from images.txt

### DIFF
--- a/images.txt
+++ b/images.txt
@@ -86,7 +86,6 @@ mono:latest
 mysql:latest
 nats:latest
 neo4j:latest
-nextcloud:latest
 nginx:latest
 nginx:alpine
 node:latest


### PR DESCRIPTION
nextcloud:latest doesn't work with trivy for a reason I don't understand. Removing for now.