### PR TITLE
Drop the vulnz attestation from the rumble action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -37,4 +37,3 @@ runs:
     - -invocation-event-id=${{ inputs.invocation-event-id }}
     - -invocation-uri=${{ inputs.invocation-uri }}
     - -docker-config=${{ inputs.docker-config }}
-    - -attest


### PR DESCRIPTION
This isn't particularly valuable unless we have the capacity to refresh it on "live" images, so let's find a different way to drive this.