### PR TITLE
Increasing trivy timeout to hopefully avoid scan errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,7 +201,7 @@ func scanImageTrivy(image string, format string, dockerConfig string) (string, *
 	if dockerConfig != "" {
 		env = append(env, fmt.Sprintf("DOCKER_CONFIG=%s", dockerConfig))
 	}
-	args := []string{"--debug", "image", "--offline-scan", "-f", format, "-o", file.Name(), image}
+	args := []string{"--debug", "image", "--timeout", "15m", "--offline-scan", "-f", format, "-o", file.Name(), image}
 	fmt.Printf("Running scan command \"trivy %s\"...\n", strings.Join(args, " "))
 	cmd := exec.Command("trivy", args...)
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Increasing the Trivy timeout to 15 mins, the current default is 5 mins. We are currently seeing a "context deadline exceeded"

Based on this [issue](https://github.com/aquasecurity/trivy/issues/802) in Trivy and this [comment](https://github.com/aquasecurity/trivy/issues/802#issuecomment-924185264), I think we could try passing a --timeout arg to Trivy. 

Additionally, from the Trivy [documentation](https://aquasecurity.github.io/trivy/v0.22.0/getting-started/troubleshooting/):
"Your scan may time out. Java takes a particularly long time to scan. Try increasing the value of the ---timeout option such as --timeout 15m."
