### PR TITLE
Filter unwanted images from scan targets

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -25,9 +25,15 @@ jobs:
           identity: 720909c9f5279097d847ad02a2f24ba8f59de36a/a033a6fabe0bfa0d
       - id: list-images
         run: |
-          chainctl img ls --group 720909c9f5279097d847ad02a2f24ba8f59de36a -ojson > image-list.json
+          image_list="$(chainctl img ls --group 720909c9f5279097d847ad02a2f24ba8f59de36a -o json)"
 
-          echo images=$(cat image-list.json | jq -c '[ .[] | select(.tags[].name | contains("latest")) | "cgr.dev/chainguard/" + .repo.name + ":latest" ] | unique') >> $GITHUB_OUTPUT
+          unwanted_images=("alpine-base" "sdk" "spire")
+
+          for img in ${unwanted_images[@]}; do
+            image_list=$(echo "$image_list" | jq "map(select(.repo.name != \"$img\"))")
+          done
+
+          echo images=$(echo $image_list | jq -c '[ .[] | select(.tags[].name | contains("latest")) | "cgr.dev/chainguard/" + .repo.name + ":latest" ] | unique') >> $GITHUB_OUTPUT
 
   scan-chainguard:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Some images shouldn't be scanned because they are no longer being built. Including these images in Rumble's output distorts downstream metrics and adds noise to the dataset.

Today, Rumble derives its list of images to scan using a `chainctl` command. This command lets us dynamically look up images of interest; however, today it's also returning a few of the problematic images. We hope to do some related cleanup work that will result in `chainctl` not returning the problematic images.

Until that's ready, this PR cleans up the mess on the Rumble side and downstream of Rumble's processing. Once the upstream cleanup is finished, we can revert this PR!

cc: @jspeed-meyers @jdolitsky @imjasonh @mattmoor 