### PR TITLE
Ignore k3s-images:latest

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           image_list="$(chainctl img ls --group 720909c9f5279097d847ad02a2f24ba8f59de36a -o json)"
 
-          unwanted_images=("alpine-base" "sdk" "spire")
+          unwanted_images=("alpine-base" "k3s-images" "sdk" "spire")
 
           for img in ${unwanted_images[@]}; do
             image_list=$(echo "$image_list" | jq "map(select(.repo.name != \"$img\"))")


### PR DESCRIPTION
It's been failing consistently with:

```console
failed to catalog: could not fetch image "cgr.dev/chainguard/k3s-images:latest": unable to use OciRegistry source: failed to get image descriptor from registry: GET https://cgr.dev/v2/chainguard/k3s-images/manifests/latest: MANIFEST_UNKNOWN: Unknown manifest
```

(Latest job run: https://github.com/chainguard-dev/rumble/actions/runs/5506740051/jobs/10035870769)

Reproducible with:

```console
$ crane manifest cgr.dev/chainguard/k3s-images:latest
Error: fetching manifest cgr.dev/chainguard/k3s-images:latest: GET https://cgr.dev/v2/chainguard/k3s-images/manifests/latest: MANIFEST_UNKNOWN: Unknown manifest
```

📣 Feel free to just close this PR if there's a better immediate solution! 😃 
