### PR TITLE
Do image build before image scan each day

### DIFF
--- a/.github/workflows/rumble-image-publish.yml
+++ b/.github/workflows/rumble-image-publish.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 11 * * *' # 6am eastern
+    - cron: '0 8 * * *' # 8am UTC — 2 hours before daily scan
   workflow_dispatch: {}
 env:
   REF: "ghcr.io/chainguard-dev/rumble:latest"


### PR DESCRIPTION
Currently, the daily image build is happening 1 hour after the daily image scan — so improvements to scanning that would be incorporated in an image build take 23 hours to show up in scan data, when they could otherwise show in the data much faster.

This PR adjusts the daily image build schedule to happen 2 hours before the daily scan each day.