### PR TITLE
Change GCLOUD_TABLE to a input instead of a secret.

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,13 +1,19 @@
 name: scan
 on:
   schedule:
-    - cron: '0 10 * * *' # 10 UTC
-  workflow_dispatch: {}
+    - cron: "0 10 * * *" # 10 UTC
+  workflow_dispatch:
+    inputs:
+      GCLOUD_TABLE:
+        description: "gcloud bigquery table to publish results to"
+        required: true
+        default: "scheduled"
+
 env:
   REF: "ghcr.io/chainguard-dev/rumble:latest"
   GCLOUD_PROJECT: ${{ secrets.GCLOUD_PROJECT }}
   GCLOUD_DATASET: ${{ secrets.GCLOUD_DATASET }}
-  GCLOUD_TABLE: ${{ secrets.GCLOUD_TABLE }}
+  GCLOUD_TABLE: ${{ inputs.GCLOUD_TABLE }}
   GCLOUD_TABLE_VULNS: ${{ secrets.GCLOUD_TABLE_VULNS }}
   GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64 }}
 concurrency: scan


### PR DESCRIPTION
GitHub Actions filters any output values that contain a secret. Turns out, this started matching one of the images, which started causing some problems since the matrix generation couldn't parse an empty string.

This value isn't really sensitive, but secrets happened to be a convinient way to set this out of band of the action itself. Moving to an input so that this can still be configured, but will default to the current value. We probably need to also delete the secret once this PR is submitted.